### PR TITLE
allow appcontext to be null in permission call

### DIFF
--- a/messaging/src/main/java/com/ortto/messaging/Ortto.java
+++ b/messaging/src/main/java/com/ortto/messaging/Ortto.java
@@ -204,6 +204,10 @@ public class Ortto {
      * @return bool
      */
     public boolean hasUserGrantedPushPermissions() {
+        if (appContext == null || appContext.getApplicationContext() == null) {
+            return false;
+        }
+
         NotificationManager manager = (NotificationManager) appContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
         if (!manager.areNotificationsEnabled()) {


### PR DESCRIPTION
Fixes an issue where `com.google.firebase.MESSAGING_EVENT` is called on first install and appContext is not yet set