### PR TITLE
exclude ActionItem and LinkUtm classes from proguard

### DIFF
--- a/messaging/proguard-rules.pro
+++ b/messaging/proguard-rules.pro
@@ -24,6 +24,8 @@
 # This ensures Gson can correctly serialize/deserialize based on field names or @SerializedName annotations
 -keep class com.ortto.messaging.identity.** { *; }
 -keep class com.ortto.messaging.retrofit.** { *; }
+-keep class com.ortto.messaging.ActionItem { *; }
+-keep class com.ortto.messaging.data.LinkUtm { *; }
 -keep class com.ortto.messaging.widget.QueuedWidget { *; } # Keep specifically for SharedPreferences/Gson
 
 # Keep JavaScript Interface class and methods


### PR DESCRIPTION
Add the following classes to the list of excluded so proguard doesn't obfuscate the serialized keys

com.ortto.messaging.ActionItem 
com.ortto.messaging.data.LinkUtm 