### PR TITLE
Chore/sdk modernization may 2026

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -4,16 +4,18 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Lint 
+    name: Lint
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
-        with: 
+      - uses: actions/setup-java@v4
+        with:
           distribution: 'temurin'
           java-version: 18
 
       - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew lint
 
@@ -28,12 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 18
 
       - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Run Tests
         run: ./gradlew test
@@ -43,4 +47,3 @@ jobs:
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/test*/TEST-*.xml'
-

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.0'
-        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
+        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Mon Mar 03 14:28:49 AEDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -15,7 +15,7 @@ ext {
 
 android {
     namespace "com.ortto.messaging"
-    compileSdkVersion 34
+    compileSdk 36
 
     publishing {
         singleVariant("release") {
@@ -25,7 +25,7 @@ android {
 
     defaultConfig {
         minSdk 26
-        targetSdk 33
+        targetSdk 35
         versionCode 3
         versionName PUBLISH_VERSION
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -45,8 +45,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_18
-        targetCompatibility JavaVersion.VERSION_18
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     testOptions {
@@ -62,21 +62,22 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.7.2'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
-    implementation platform('com.google.firebase:firebase-bom:31.0.2')
+    implementation 'com.squareup.retrofit2:retrofit:3.0.0'
+    implementation 'com.squareup.retrofit2:converter-gson:3.0.0'
+    implementation 'com.squareup.retrofit2:converter-scalars:3.0.0'
+    implementation platform('com.google.firebase:firebase-bom:34.13.0')
 
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.3.2'
+    implementation 'com.squareup.okhttp3:logging-interceptor:5.3.2'
 
     implementation 'com.google.firebase:firebase-messaging'
-    implementation 'androidx.webkit:webkit:1.4.0'
+    implementation 'com.google.android.gms:play-services-base'
+    implementation 'androidx.webkit:webkit:1.16.0'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.robolectric:robolectric:4.10.3"
-    testImplementation 'org.mockito:mockito-core:5.8.0'
+    testImplementation "org.robolectric:robolectric:4.14.1"
+    testImplementation 'org.mockito:mockito-core:5.14.2'
 }
 
 if ("Messaging SDK" == rootProject.name) {

--- a/messaging/src/main/AndroidManifest.xml
+++ b/messaging/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ortto.messaging">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
# sdk modernization, may 2026
  
Routine bump of deps + toolchain. no api changes, consumers shouldn't notice anything.

  ### deps
  - firebase-bom 31.0.2 -> 34.13.0
  - retrofit 2.9.0 -> 3.0.0 (gson + scalars converters too)
  - okhttp 4.12.0 -> 5.3.2 (this is what retrofit 3 ships with)
  - androidx.webkit 1.4.0 -> 1.16.0
  - dropped the manual play-services-base pin, firebase bom handles it now so versions cant drift

  ### toolchain
  - compileSdk 34 -> 36, targetSdk 33 -> 35
  - gradle 8.5 -> 8.14.5, agp 8.3.0 -> 8.13.2
  - java 18 -> 17. 18 was a weird choice, as its not even an lts release (eol'd back in 2022). 17 is what studio bundles, so consumers wont need to mess with their jdk.

  ### not in this pr
  - tried bumping to agp 9 / gradle 9 but hit plugin compat stuff, splitting that into its own pr. 8.13 keeps us current on the v8 line for now.

  ### testing
  - [x] gradle build passes
  - [x] unit tests green
  - [x] smoke test the demo app: push receive, identify, register device token
